### PR TITLE
请升级com.thoughtworks.xstream:xstream组件版本以解决2个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.19</version>
+            <version>1.4.20</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
将 **com.thoughtworks.xstream:xstream** 组件从1.4.19 版本升级至 1.4.20版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-57066](https://www.oscs1024.com/hd/MPS-2022-57066) | xstream project跨界内存写漏洞 | 高危
2 | [MPS-2022-58603](https://www.oscs1024.com/hd/MPS-2022-58603) | XStream < 1.4.20 栈缓冲区溢出漏洞 | 中危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
